### PR TITLE
h-branch-22

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import { Montserrat } from "next/font/google";
 import "./globals.css";
 import React from "react";
-import { Toaster } from "@/components/ui/sonner";
-import VerifyTokenProvider from "@/providers/verifyTokenProvider";
+import OfflineProvider from "@/providers/offlineProvider";
 
 const montserrat = Montserrat({
   variable: "--font-montserrat",
@@ -33,8 +32,7 @@ export default function RootLayout({
   return (
     <html lang="tr">
       <body className={`${montserrat.variable} antialiased`}>
-        <VerifyTokenProvider>{children}</VerifyTokenProvider>
-        <Toaster richColors />
+        <OfflineProvider>{children}</OfflineProvider>
       </body>
     </html>
   );

--- a/components/offline.tsx
+++ b/components/offline.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { WifiOff, Wifi, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+
+const CONNECTION_CHECK_DELAY = 2000; // 2 saniye bekle
+
+type Status = 'checking' | 'online' | 'offline';
+
+const Offline = () => {
+  const [status, setStatus] = useState<Status | string>('checking');
+  const [retryCount, setRetryCount] = useState(0);
+
+  const checkConnection = async (isRetry = false) => {
+    if (isRetry) {
+      setStatus('checking');
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+    
+    // Sunucuya basit bir istek atarak bağlantıyı kontrol et
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 3000); // 3 saniye zaman aşımı
+      
+      const response = await fetch('/api/health', {
+        method: 'HEAD',
+        cache: 'no-store',
+        signal: controller.signal
+      });
+      
+      clearTimeout(timeoutId);
+      
+      if (response.ok) {
+        setStatus('online');
+        // 2 saniye bekle ve sayfayı yenile
+        setTimeout(() => window.location.reload(), 2000);
+      } else {
+        setStatus('offline');
+      }
+    } catch (error) {
+      setStatus('offline');
+    }
+  };
+
+  useEffect(() => {
+    const checkInitialConnection = async () => {
+      // İlk yüklemede biraz bekle
+      await new Promise(resolve => setTimeout(resolve, CONNECTION_CHECK_DELAY));
+      await checkConnection();
+    };
+
+    checkInitialConnection();
+
+    const handleOnline = () => checkConnection();
+    const handleOffline = () => setStatus('offline');
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  // Yükleme durumunda
+  if (status === 'checking') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen p-4 text-center">
+        <div className="p-6 mb-4">
+          <Loader2 className="w-12 h-12 text-blue-600 animate-spin" />
+        </div>
+        <h1 className="text-2xl font-bold text-gray-800 mb-2">Bağlantı Kontrol Ediliyor...</h1>
+        <p className="text-gray-600">Lütfen bekleyiniz.</p>
+      </div>
+    );
+  }
+
+  // Çevrimiçi durumunda
+  if (status === 'online') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen p-4 text-center">
+        <div className="p-6 bg-green-100 rounded-full mb-4">
+          <Wifi className="w-12 h-12 text-green-600" />
+        </div>
+        <h1 className="text-2xl font-bold text-gray-800 mb-2">Bağlantı Kuruldu!</h1>
+        <p className="text-gray-600 mb-6">Yönlendiriliyorsunuz...</p>
+      </div>
+    );
+  }
+
+  // Çevrimdışı durumunda
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4 text-center">
+      <div className="p-6 bg-red-100 rounded-full mb-4">
+        <WifiOff className="w-12 h-12 text-red-600" />
+      </div>
+      <h1 className="text-2xl font-bold text-gray-800 mb-2">İnternet Bağlantısı Yok</h1>
+      <p className="text-gray-600 mb-6">
+        Uygulamaya erişmek için internet bağlantınızın olduğundan emin olun.
+      </p>
+      <div className="flex flex-col sm:flex-row gap-4">
+        <Button 
+          onClick={() => {
+            setRetryCount(prev => prev + 1);
+            checkConnection(true);
+          }} 
+          variant="outline" 
+          className="gap-2"
+          disabled={status === 'checking'}
+        >
+          {status === 'checking' ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Wifi className="w-4 h-4" />
+          )}
+          Yeniden Dene {retryCount > 0 && `(${retryCount})`}
+        </Button>
+        <Button 
+          onClick={() => window.location.reload()}
+          disabled={status === 'checking'}
+        >
+          Sayfayı Yenile
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default Offline;

--- a/providers/offlineProvider.tsx
+++ b/providers/offlineProvider.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Toaster } from "@/components/ui/sonner";
+import VerifyTokenProvider from "@/providers/verifyTokenProvider";
+import Offline from "@/components/offline";
+
+const OfflineProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isOnline, setIsOnline] = useState(false);
+
+  useEffect(() => {
+    // İlk yüklemede mevcut durumu ayarla
+    setIsOnline(navigator.onLine);
+    
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return (
+    <>
+      {isOnline ? (
+        <>
+          <VerifyTokenProvider>{children}</VerifyTokenProvider>
+          <Toaster richColors />
+        </>
+      ) : (
+        <Offline />
+      )}
+    </>
+  );
+};
+
+export default OfflineProvider;


### PR DESCRIPTION
Here is the pull request description based on the provided context:

```
## Changes

- Implemented new cut dialog logic:
  - Introduced a `shownCutIds` set to track the IDs of the cuts that have already been displayed in the dialog.
  - Implemented a new logic to check if the current cut dialog is new (not previously shown) before displaying it.
  - Added a timeout to automatically close the dialog after 3 seconds.
  - Implemented a periodic cleanup of the `shownCutIds` set to remove old cut IDs (e.g., every 1 hour).
  - Optimized the interval for fetching the cut dialog to only run when the modal is not open.
- Improved modal handling and polling logic for the cut dialog:
  - Removed the `isModalOpen` check before fetching the cut dialog.
  - Introduced a short delay (2.5 seconds) before automatically closing the modal.
  - Added a new effect that checks for a new cut dialog immediately after the modal is closed.
  - Optimized the polling logic to only fetch new cut information when the modal is not open and the user is not a super admin.
- Implemented offline mode with connection checking:
  - Implemented the `OfflineProvider` component that manages the online/offline state and renders the appropriate UI.
  - Created the `Offline` component that displays the offline UI with a connection status indicator and a retry button.
  - Added event listeners to monitor the online/offline state changes and update the UI accordingly.
  - Implemented a connection check function that makes a simple request to the server to determine the connection status.
  - Provided a loading state while the initial connection check is being performed.
```