### PR TITLE
feat: Change API URL based on environment

### DIFF
--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -5,7 +5,7 @@ export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
   token?: string;
 }
 
-export const apiUrl=process.env.NODE_ENV === "production" ? "https://kurban.hakankorkmaz.dev/api/v1" : "http://127.0.0.1:8000/api/v1";
+export const apiUrl=process.env.NODE_ENV === "production" ? "https://erdalyasar.com/api/v1" : "http://127.0.0.1:8000/api/v1";
 
 const axiosInstance: AxiosInstance = axios.create({
   timeout: 25000,


### PR DESCRIPTION
- Updated the `apiUrl` constant in the `axios.ts` file to use a different API URL based on the environment
- In production, the URL is set to `https://erdalyasar.com/api/v1`
- In development, the URL remains `http://127.0.0.1:8000/api/v1`
- This change ensures the application uses the correct API endpoint for the current environment